### PR TITLE
Add re-login modal

### DIFF
--- a/200.html
+++ b/200.html
@@ -13,6 +13,21 @@ setTimeout(function(){l(e)})},s.addEventListener&&s.addEventListener("load",func
 "undefined"!=typeof exports?exports.loadCSS=n:e.loadCSS=n}("undefined"!=typeof global?global:this)
         </script>
 <style>
+.relog-in-box {
+  position: absolute;
+  display: flex;
+  z-index: 100;
+  width: 100vw;
+  height: 100vh;
+  justify-content: center;
+  align-items: center;
+}
+.relog-in-box__content {
+  background-color: #f5f5f5;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid #e6e6e4;
+}
 .log-in-box {
   height: 100vh;
   width: 100vw;

--- a/200.html
+++ b/200.html
@@ -15,16 +15,23 @@ setTimeout(function(){l(e)})},s.addEventListener&&s.addEventListener("load",func
 <style>
 .relog-in-box {
   position: absolute;
+  top: 0;
+  left: 0;
   display: flex;
   z-index: 100;
   width: 100vw;
   height: 100vh;
   justify-content: center;
   align-items: center;
+  background-color: rgba(0, 0, 0, 0.78);
+}
+.relog-in-box__subtitle {
+  font-size: 1.3em;
+  text-align: justify;
 }
 .relog-in-box__content {
   background-color: #f5f5f5;
-  padding: 10px;
+  padding: 20px;
   border-radius: 10px;
   border: 1px solid #e6e6e4;
 }
@@ -46,6 +53,24 @@ setTimeout(function(){l(e)})},s.addEventListener&&s.addEventListener("load",func
   font-weight: 400;
   color: #fff;
   margin: 20px;
+}
+.relog-in-box__button {
+  width: 80%;
+  margin: 4px;
+  font-size: 140%;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  border: 0;
+  color: white;
+}
+.relog-in-box__button:hover {
+  background-color: #44C7F4;
+}
+.relog-in-box__button:focus {
+  outline: none !important;
+}
+.relog-in-box__button.btn-lg {
+  padding: 20px 50px;
 }
 .log-in-box__button {
   font-size: 140%;

--- a/app/components/app.js
+++ b/app/components/app.js
@@ -22,7 +22,7 @@ class App extends React.Component {
   }
 
   getUserInfo( props ) {
-    if ( props.auth.token && ! props.auth.user ) {
+    if ( props.auth.token && ! props.auth.user && ! props.auth.expiredToken ) {
       props.getProfile();
     }
   }

--- a/app/components/app.js
+++ b/app/components/app.js
@@ -8,7 +8,7 @@ import LogInBox from 'components/log-in-box';
 
 class App extends React.Component {
   componentWillMount() {
-    if ( ! this.props.auth.token ) {
+    if ( ! this.props.auth.token || this.props.auth.expiredToken ) {
       this.props.parseAuthToken();
     }
   }

--- a/app/components/logged-in.js
+++ b/app/components/logged-in.js
@@ -33,7 +33,7 @@ class LoggedIn extends React.Component {
   }
 
   mainKeyListener = ( evt ) => {
-    if ( this.props.isShowingAddLocation || this.props.editingLocation ) return;
+    if ( this.props.isShowingAddLocation || this.props.editingLocation || this.props.auth.expiredToken ) return;
     switch ( evt.keyCode ) {
       case 40:
         // pressing up and down changes the selected location
@@ -94,6 +94,7 @@ LoggedIn.propTypes = {
   library: React.PropTypes.array,
   predictions: React.PropTypes.array,
   trip: React.PropTypes.array,
+  auth: React.PropTypes.object,
   searchString: React.PropTypes.string,
   isShowingAddLocation: React.PropTypes.bool,
   editingLocation: React.PropTypes.object,
@@ -124,6 +125,7 @@ function mapStateToProps( state ) {
     editingLocation: state.ui.editingLocation,
     addingAddress: state.ui.addingAddress,
     searchString: state.ui.searchString,
+    auth: state.auth,
   };
 }
 

--- a/app/components/main.js
+++ b/app/components/main.js
@@ -27,7 +27,7 @@ class Main extends React.Component {
   render() {
     const props = this.props;
     const lastTripLocationId = ( props.trip.length > 0 ? props.trip[ props.trip.length - 1 ].id : null );
-    const isShowingModal = props.isShowingAddLocation || props.editingLocation;
+    const isShowingModal = props.isShowingAddLocation || props.editingLocation || props.auth.expiredToken;
     return (
       <div className={ classNames( 'main', { 'main--trip': props.isShowingTrip } ) }>
         <HeaderSummary />

--- a/app/components/main.js
+++ b/app/components/main.js
@@ -7,6 +7,7 @@ import Trip from 'components/trip';
 import MainQuestion from 'components/main-question';
 import HeaderSummary from 'components/header-summary';
 import LocationSearch from 'components/location-search';
+import RelogInBox from 'components/relog-in-box';
 import {
   startEditLocation,
   showAddLocation,
@@ -58,6 +59,7 @@ class Main extends React.Component {
             onDrop={ props.moveTripLocation }
           />
         </div>
+        { props.auth.expiredToken && <RelogInBox /> }
       </div>
     );
   }
@@ -73,6 +75,7 @@ function mapStateToProps( state ) {
     searchString: state.ui.searchString,
     isShowingAddLocation: state.ui.isShowingAddLocation,
     editingLocation: state.ui.editingLocation,
+    auth: state.auth,
   };
 }
 

--- a/app/components/relog-in-box.js
+++ b/app/components/relog-in-box.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import Notices from 'components/notices';
+import { clearNotices } from 'lib/actions/general';
+import { doAuthWithPassword } from 'lib/actions/auth';
+
+const RelogInBox = ( props ) => {
+  return (
+    <div className="relog-in-box">
+      <Notices errors={ props.errors } onClearNotices={ props.clearNotices } />
+      <div className="relog-in-box__content">
+        <img className="relog-in-box__logo" alt="Voyageur logo" src="/assets/logo-small.png" />
+        <p className="relog-in-box__subtitle">To complete that last calculation, I need you to log in again.</p>
+        <a onClick={ props.doAuthWithPassword } className="relog-in-box__button btn btn-primary btn-lg">Log In</a>
+      </div>
+    </div>
+  );
+};
+
+RelogInBox.propTypes = {
+  doAuthWithPassword: React.PropTypes.func.isRequired,
+  clearNotices: React.PropTypes.func.isRequired,
+  errors: React.PropTypes.array,
+};
+
+function mapStateToProps( state ) {
+  return { errors: state.notices.errors };
+}
+
+export default connect( mapStateToProps, { doAuthWithPassword, clearNotices } )( RelogInBox );
+

--- a/app/components/relog-in-box.js
+++ b/app/components/relog-in-box.js
@@ -4,19 +4,27 @@ import Notices from 'components/notices';
 import { clearNotices } from 'lib/actions/general';
 import { doAuthWithPassword, ignoreExpiredToken } from 'lib/actions/auth';
 
-const RelogInBox = ( props ) => {
-  return (
-    <div className="relog-in-box">
-      <Notices errors={ props.errors } onClearNotices={ props.clearNotices } />
-      <div className="relog-in-box__content">
-        <img className="relog-in-box__logo" alt="Voyageur logo" src="/assets/logo-small.png" />
-        <p className="relog-in-box__subtitle">Sorry, but to complete that last calculation, I need you to log in again.</p>
-        <a onClick={ props.doAuthWithPassword } className="relog-in-box__button btn btn-primary btn-lg">Log In</a>
-        <a onClick={ props.ignoreExpiredToken } className="relog-in-box__button btn btn-warning btn-lg">Cancel</a>
+class RelogInBox extends React.Component {
+  componentDidMount() {
+    if ( this.primaryButton ) this.primaryButton.focus();
+  }
+
+  render() {
+    const props = this.props;
+    const savePrimaryButton = input => this.primaryButton = input;
+    return (
+      <div className="relog-in-box">
+        <Notices errors={ props.errors } onClearNotices={ props.clearNotices } />
+        <div className="relog-in-box__content" role="dialog" aria-labelledby="relog-in-box__subtitle">
+          <img className="relog-in-box__logo" alt="Voyageur logo" src="/assets/logo-small.png" />
+          <p id="relog-in-box__subtitle" className="relog-in-box__subtitle">Sorry, but to complete that last calculation, I need you to log in again.</p>
+          <a onClick={ props.doAuthWithPassword } ref={ savePrimaryButton } className="relog-in-box__button btn btn-primary btn-lg">Log In</a>
+          <a onClick={ props.ignoreExpiredToken } className="relog-in-box__button btn btn-warning btn-lg">Cancel</a>
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+}
 
 RelogInBox.propTypes = {
   doAuthWithPassword: React.PropTypes.func.isRequired,

--- a/app/components/relog-in-box.js
+++ b/app/components/relog-in-box.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Notices from 'components/notices';
 import { clearNotices } from 'lib/actions/general';
-import { doAuthWithPassword } from 'lib/actions/auth';
+import { doAuthWithPassword, ignoreExpiredToken } from 'lib/actions/auth';
 
 const RelogInBox = ( props ) => {
   return (
@@ -10,8 +10,9 @@ const RelogInBox = ( props ) => {
       <Notices errors={ props.errors } onClearNotices={ props.clearNotices } />
       <div className="relog-in-box__content">
         <img className="relog-in-box__logo" alt="Voyageur logo" src="/assets/logo-small.png" />
-        <p className="relog-in-box__subtitle">To complete that last calculation, I need you to log in again.</p>
+        <p className="relog-in-box__subtitle">Sorry, but to complete that last calculation, I need you to log in again.</p>
         <a onClick={ props.doAuthWithPassword } className="relog-in-box__button btn btn-primary btn-lg">Log In</a>
+        <a onClick={ props.ignoreExpiredToken } className="relog-in-box__button btn btn-warning btn-lg">Cancel</a>
       </div>
     </div>
   );
@@ -19,6 +20,7 @@ const RelogInBox = ( props ) => {
 
 RelogInBox.propTypes = {
   doAuthWithPassword: React.PropTypes.func.isRequired,
+  ignoreExpiredToken: React.PropTypes.func.isRequired,
   clearNotices: React.PropTypes.func.isRequired,
   errors: React.PropTypes.array,
 };
@@ -27,5 +29,5 @@ function mapStateToProps( state ) {
   return { errors: state.notices.errors };
 }
 
-export default connect( mapStateToProps, { doAuthWithPassword, clearNotices } )( RelogInBox );
+export default connect( mapStateToProps, { doAuthWithPassword, clearNotices, ignoreExpiredToken } )( RelogInBox );
 

--- a/app/lib/actions/auth.js
+++ b/app/lib/actions/auth.js
@@ -59,3 +59,7 @@ export function gotProfile( allUserData ) {
 export function logOut() {
   return { type: 'AUTH_LOG_OUT' };
 }
+
+export function ignoreExpiredToken() {
+	return { type: 'AUTH_IGNORE_EXPIRED_TOKEN' };
+}

--- a/app/lib/reducers/auth.js
+++ b/app/lib/reducers/auth.js
@@ -9,6 +9,8 @@ export default function auth( state = initialState, action ) {
         return Object.assign( {}, state, { expiredToken: true } );
       }
       break;
+    case 'AUTH_IGNORE_EXPIRED_TOKEN':
+      return Object.assign( {}, state, { expiredToken: false } );
     case 'AUTH_GOT_TOKEN':
       return Object.assign( {}, state, { token: action.token, expiredToken: false } );
     case 'AUTH_GOT_USER':

--- a/app/lib/reducers/auth.js
+++ b/app/lib/reducers/auth.js
@@ -1,16 +1,16 @@
 import get from 'lodash.get';
 
-const initialState = { token: null, user: null };
+const initialState = { token: null, user: null, expiredToken: false };
 export default function auth( state = initialState, action ) {
   switch ( action.type ) {
     case 'ERROR':
       const text = get( action, 'error.response.text', '' );
       if ( text.match( /expired|unauthorized/i ) ) {
-        return initialState;
+        return Object.assign( {}, state, { expiredToken: true } );
       }
       break;
     case 'AUTH_GOT_TOKEN':
-      return Object.assign( {}, state, { token: action.token } );
+      return Object.assign( {}, state, { token: action.token, expiredToken: false } );
     case 'AUTH_GOT_USER':
       return Object.assign( {}, state, { user: action.user } );
     case 'AUTH_LOG_OUT':

--- a/app/lib/reducers/auth.js
+++ b/app/lib/reducers/auth.js
@@ -6,7 +6,7 @@ export default function auth( state = initialState, action ) {
     case 'ERROR':
       const text = get( action, 'error.response.text', '' );
       if ( text.match( /expired|unauthorized/i ) ) {
-        return Object.assign( {}, initialState );
+        return initialState;
       }
       break;
     case 'AUTH_GOT_TOKEN':

--- a/app/lib/reducers/auth.js
+++ b/app/lib/reducers/auth.js
@@ -3,6 +3,8 @@ import get from 'lodash.get';
 const initialState = { token: null, user: null, expiredToken: false };
 export default function auth( state = initialState, action ) {
   switch ( action.type ) {
+    case 'AUTH_SET_EXPIRED_TOKEN':
+      return Object.assign( {}, state, { expiredToken: true } );
     case 'ERROR':
       const text = get( action, 'error.response.text', '' );
       if ( text.match( /Expired token/i ) ) {

--- a/app/lib/reducers/auth.js
+++ b/app/lib/reducers/auth.js
@@ -5,8 +5,10 @@ export default function auth( state = initialState, action ) {
   switch ( action.type ) {
     case 'ERROR':
       const text = get( action, 'error.response.text', '' );
-      if ( text.match( /expired|unauthorized/i ) ) {
+      if ( text.match( /Expired token/i ) ) {
         return Object.assign( {}, state, { expiredToken: true } );
+      } else if ( text.match( /unauthorized/i ) ) {
+        return initialState;
       }
       break;
     case 'AUTH_IGNORE_EXPIRED_TOKEN':

--- a/index.html
+++ b/index.html
@@ -13,6 +13,21 @@ setTimeout(function(){l(e)})},s.addEventListener&&s.addEventListener("load",func
 "undefined"!=typeof exports?exports.loadCSS=n:e.loadCSS=n}("undefined"!=typeof global?global:this)
         </script>
 <style>
+.relog-in-box {
+  position: absolute;
+  display: flex;
+  z-index: 100;
+  width: 100vw;
+  height: 100vh;
+  justify-content: center;
+  align-items: center;
+}
+.relog-in-box__content {
+  background-color: #f5f5f5;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid #e6e6e4;
+}
 .log-in-box {
   height: 100vh;
   width: 100vw;

--- a/index.html
+++ b/index.html
@@ -15,16 +15,23 @@ setTimeout(function(){l(e)})},s.addEventListener&&s.addEventListener("load",func
 <style>
 .relog-in-box {
   position: absolute;
+  top: 0;
+  left: 0;
   display: flex;
   z-index: 100;
   width: 100vw;
   height: 100vh;
   justify-content: center;
   align-items: center;
+  background-color: rgba(0, 0, 0, 0.78);
+}
+.relog-in-box__subtitle {
+  font-size: 1.3em;
+  text-align: justify;
 }
 .relog-in-box__content {
   background-color: #f5f5f5;
-  padding: 10px;
+  padding: 20px;
   border-radius: 10px;
   border: 1px solid #e6e6e4;
 }
@@ -46,6 +53,24 @@ setTimeout(function(){l(e)})},s.addEventListener&&s.addEventListener("load",func
   font-weight: 400;
   color: #fff;
   margin: 20px;
+}
+.relog-in-box__button {
+  width: 80%;
+  margin: 4px;
+  font-size: 140%;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  border: 0;
+  color: white;
+}
+.relog-in-box__button:hover {
+  background-color: #44C7F4;
+}
+.relog-in-box__button:focus {
+  outline: none !important;
+}
+.relog-in-box__button.btn-lg {
+  padding: 20px 50px;
 }
 .log-in-box__button {
   font-size: 140%;


### PR DESCRIPTION
This will prevent user confusion when the JWT token expires (like #13) by providing a better UX for refreshing the token.

To do:
- [x] Make sure actual auth failures don't get the modal (causing an infinite loop).
- [x] Disable keyboard shortcuts when modal is displayed.
- [ ] Don't just say "Loading..." forever if the user cancels the modal. Not sure what else to do... #18
- [x] Make sure modal is focused (a11y).
- [ ] Make sure the input field is focused when the modal is closed ([a11y](https://www.marcozehe.de/2015/02/05/advanced-aria-tip-2-accessible-modal-dialogs/)). #14 
- [x] Make sure auth errors show as errors over the modal (especially at mobile width).
- [ ] Disable scrolling when modal is visible (or have the overlay cover the whole page). #17 